### PR TITLE
Remove unneeded mutex. Fix a test.

### DIFF
--- a/include/worker-pool/worker-pool.h
+++ b/include/worker-pool/worker-pool.h
@@ -106,7 +106,6 @@ namespace worker_pool {
             [[nodiscard]] TIterator getIterator() const;
 
 #if defined(WORKER_POOL_DEADLOCK_DETECTION) || defined(WORKER_POOL_DEADLOCK_DETECTION_STRICT)
-            std::mutex waitingForMutex;
             WorkItem* waitingFor = nullptr;
 #endif
         };

--- a/src/worker-pool.cpp
+++ b/src/worker-pool.cpp
@@ -197,9 +197,7 @@ namespace worker_pool {
             toAwait.getName().c_str());
         // Walk the wait chain, looking for the WorkItem we're currently executing.
         auto* waitingFor = &toAwait;
-        std::list<std::unique_lock<std::mutex>> locks;
         while (waitingFor) {
-            locks.emplace_back(waitingFor->waitingForMutex, std::adopt_lock);
             auto* waitingForNext = waitingFor->waitingFor;
             log("%s is waiting for %s", waitingFor->name.c_str(),
                 waitingForNext ? waitingForNext->name.c_str() : "nothing");
@@ -220,7 +218,6 @@ namespace worker_pool {
 
 #define PUSH_WAITING_FOR do { \
     if (executingWorkItem) { \
-        std::lock_guard waitingForLock(executingWorkItem->waitingForMutex); \
         oldWaitingFor = executingWorkItem->waitingFor; \
         executingWorkItem->waitingFor = workItem.get(); \
         log("%s is now awaiting %s", executingWorkItem->getName().c_str(), workItem->getName().c_str()); \

--- a/test/src/TestDetectDeadlock.cpp
+++ b/test/src/TestDetectDeadlock.cpp
@@ -31,8 +31,10 @@ TEST(Deadlock, Simple) {
     });
     pt2.store(&t2, std::memory_order::release);
     t1.wait();
-    t2.get();
-    EXPECT_THROW(t1.get(), deadlock_exception);
+    EXPECT_THROW({
+        t1.get();
+        t2.get();
+        }, deadlock_exception);
 }
 
 TEST(Deadlock, Two) {


### PR DESCRIPTION
The critical section for `deadlockCheckMutex` completely covers that the sections where the per-task `waitingForMutex` locks are held. Therefore, the per-task mutex can be removed.